### PR TITLE
feat: expose dns servers as module variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,6 +171,7 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
   security_group_ids     = concat([aws_security_group.this[0].id], var.security_group_ids)
   vpn_port               = var.vpn_port
   self_service_portal    = var.self_service_portal
+  dns_servers            = var.dns_servers
 
   authentication_options {
     type                           = var.authentication_type

--- a/variables.tf
+++ b/variables.tf
@@ -220,3 +220,12 @@ variable "enable_security_group" {
   default     = true
   description = "create for security group module this value is enable 'true'"
 }
+
+variable "dns_servers" {
+  type = list(string)
+  validation {
+    condition = length(dns_servers) > 2
+    error_message = "A Client VPN endpoint can have up to two DNS servers"
+  }
+  description = "Information about the DNS servers to be used for DNS resolution"
+}


### PR DESCRIPTION
## what
* Existing variable in `ec2_client_vpn_endpoint` to specify the DNS servers of the VPN endpoint

## why
* Control the DNS servers of the VPN endpoint

## references
* https://registry.terraform.io/providers/hashicorp/aws/3.1.0/docs/resources/ec2_client_vpn_endpoint#dns_servers
